### PR TITLE
Change of ACL handling

### DIFF
--- a/admin/models/DbTable/Resources.php
+++ b/admin/models/DbTable/Resources.php
@@ -8,15 +8,12 @@ class Admin_Model_DbTable_Resources extends Npl_Db_Table_Abstract
      */
     protected $_name = 'npl_admin_resources';
 
-    public function fetchResources ()
+    public function findByControllerAction ($controller, $action)
     {
         $select = new Zend_Db_Table_Select($this);
-        $select->from($this->_name, array(
-                'id',
-                'controller_name'
-        ))
-            ->order('id')
-            ->group('controller_name');
+        $select->from($this->_name)
+            ->where('controller_name = ?', $controller)
+            ->where('action_name = ?', $action);
         return $this->fetchAll($select);
     }
 }

--- a/admin/models/DbTable/Roles.php
+++ b/admin/models/DbTable/Roles.php
@@ -7,4 +7,9 @@ class Admin_Model_DbTable_Roles extends Npl_Db_Table_Abstract
      * Tabellenname
      */
     protected $_name = 'npl_admin_roles';
+
+    public function findByRoleName($roleName) {
+        $where = $this->getAdapter()->quoteInto('name = ?', $roleName);
+        return $this->fetchAll($where);
+    }
 }

--- a/admin/models/Resource.php
+++ b/admin/models/Resource.php
@@ -1,6 +1,6 @@
 <?php
 
-class Admin_Model_Resource
+class Admin_Model_Resource implements Zend_Acl_Resource_Interface
 {
 
     protected $_id;
@@ -57,6 +57,11 @@ class Admin_Model_Resource
     public function getId ()
     {
         return $this->_id;
+    }
+
+    public function getResourceId()
+    {
+        return $this->getId();
     }
 
     public function setControllerName ($controllerName)

--- a/admin/models/Role.php
+++ b/admin/models/Role.php
@@ -1,6 +1,6 @@
 <?php
 
-class Admin_Model_Role
+class Admin_Model_Role implements Zend_Acl_Role_Interface
 {
 
     protected $_id;
@@ -55,6 +55,11 @@ class Admin_Model_Role
     public function getId ()
     {
         return $this->_id;
+    }
+
+    public function getRoleId()
+    {
+        return $this->getId();
     }
 
     public function setName ($name)

--- a/admin/models/mappers/ResourcesMapper.php
+++ b/admin/models/mappers/ResourcesMapper.php
@@ -53,18 +53,14 @@ class Admin_Model_Mapper_ResourcesMapper
         $this->_setValues($row, $resource);
     }
 
-    public function fetchResources ()
+    public function findByControllerAction($controller, $action, Admin_Model_Resource $resource)
     {
-        // Notice: Can't be simplified by _fetch because it has not all columns
-        $resultSet = $this->getDbTable()->fetchResources();
-        $roles = array();
-        foreach ($resultSet as $row) {
-            $role = new Admin_Model_Resource();
-            $role->setId($row->id);
-            $role->setControllerName($row->controller_name);
-            $roles[] = $role;
+        $result = $this->getDbTable()->findByControllerAction($controller, $action);
+        if (0 == count($result)) {
+            return;
         }
-        return $roles;
+        $row = $result->current();
+        $this->_setValues($row, $resource);
     }
 
     public function fetchAll ()

--- a/admin/models/mappers/RolesMapper.php
+++ b/admin/models/mappers/RolesMapper.php
@@ -52,6 +52,11 @@ class Admin_Model_Mapper_RolesMapper
         $this->_setValues($row, $role);
     }
 
+    public function findByRoleName($roleName) {
+        return $this->_fetch($this->getDbTable()
+            ->findByRoleName($roleName));
+    }
+
     public function fetchAll ()
     {
         return $this->_fetch($this->getDbTable()

--- a/admin/plugins/Auth/AccessControll.php
+++ b/admin/plugins/Auth/AccessControll.php
@@ -29,15 +29,16 @@ class Admin_Plugin_Auth_AccessControll extends Zend_Controller_Plugin_Abstract
         
         $controller = $request->getControllerName();
         $action = $request->getActionName();
-        
-        $this->_acl->has($controller) == true ? $resource = $controller : $resource = null;
-        $privilege = $action;
+
+        $resource = new Admin_Model_Resource();
+        $resourceMapper = new Admin_Model_Mapper_ResourcesMapper();
+        $resourceMapper->findByControllerAction($controller, $action, $resource);
         
         $allowed = false;
         foreach ($userroles as $userrole) {
             $role = new Admin_Model_Role();
             $roleMapper->find($userrole->getRoleId(), $role);
-            if ($this->_acl->isAllowed($role->getName(), $resource, $privilege)) {
+            if ($this->_acl->isAllowed($role, $resource)) {
                 $allowed = true;
             }
         }

--- a/admin/plugins/Auth/Acl.php
+++ b/admin/plugins/Auth/Acl.php
@@ -47,11 +47,16 @@ class Admin_Plugin_Auth_Acl extends Zend_Acl
 
         $loginResource = new Admin_Model_Resource();
         $mapperResources->findByControllerAction('auth', 'login', $loginResource);
-        
-        // Allow everthing to administrator except login (Login not needed
-        // 'cause of already logged in)
-        $this->allow(1);
-        $this->deny(1, $loginResource);
+
+        $adminRole = new Admin_Model_Role();
+        $mapperRoles->findByRoleName('Administrator', $adminRole);
+
+        if ($adminRoleId = $adminRole->getRoleId()) {
+            // Allow everything to administrator except login (Login not needed
+            // 'cause of already logged in)
+            $this->allow($adminRoleId);
+            $this->deny($adminRoleId, $loginResource);
+        }
 
         $errorResource = new Admin_Model_Resource();
         $mapperResources->findByControllerAction('error', '', $errorResource);

--- a/admin/plugins/Auth/Acl.php
+++ b/admin/plugins/Auth/Acl.php
@@ -13,11 +13,10 @@ class Admin_Plugin_Auth_Acl extends Zend_Acl
     private function initResources ()
     {
         $mapper = new Admin_Model_Mapper_ResourcesMapper();
-        $resources = $mapper->fetchResources();
+        $resources = $mapper->fetchAll();
         
         foreach ($resources as $resource) {
-            $this->addResource(
-                    new Zend_Acl_Resource($resource->getControllerName()));
+            $this->addResource($resource);
         }
     }
 
@@ -27,7 +26,7 @@ class Admin_Plugin_Auth_Acl extends Zend_Acl
         $roles = $mapper->fetchAll();
         
         foreach ($roles as $role) {
-            $this->addRole(new Zend_Acl_Role($role->getName()));
+            $this->addRole($role);
         }
     }
 
@@ -43,16 +42,21 @@ class Admin_Plugin_Auth_Acl extends Zend_Acl
             $role = new Admin_Model_Role();
             $mapperResources->find($right->getResourceId(), $resource);
             $mapperRoles->find($right->getRoleId(), $role);
-            $this->allow($role->getName(), $resource->getControllerName(), 
-                    $resource->getActionName());
+            $this->allow($right->getRoleId(), $right->getResourceId());
         }
+
+        $loginResource = new Admin_Model_Resource();
+        $mapperResources->findByControllerAction('auth', 'login', $loginResource);
         
         // Allow everthing to administrator except login (Login not needed
         // 'cause of already logged in)
-        $this->allow('Administrator');
-        $this->deny('Administrator', 'auth', 'login');
-        
+        $this->allow(1);
+        $this->deny(1, $loginResource);
+
+        $errorResource = new Admin_Model_Resource();
+        $mapperResources->findByControllerAction('error', '', $errorResource);
+
         // Allow Error-Controller (all Actions) for everyone
-        $this->allow(null, 'error');
+        $this->allow(null, $errorResource);
     }
 }

--- a/application/models/DbTable/Resources.php
+++ b/application/models/DbTable/Resources.php
@@ -8,15 +8,12 @@ class Application_Model_DbTable_Resources extends Npl_Db_Table_Abstract
      */
     protected $_name = 'npl_resources';
 
-    public function fetchResources ()
+    public function findByControllerAction ($controller, $action)
     {
         $select = new Zend_Db_Table_Select($this);
-        $select->from($this->_name, array(
-                'id',
-                'controller_name'
-        ))
-            ->order('id')
-            ->group('controller_name');
+        $select->from($this->_name)
+            ->where('controller_name = ?', $controller)
+            ->where('action_name = ?', $action);
         return $this->fetchAll($select);
     }
 }

--- a/application/models/Resource.php
+++ b/application/models/Resource.php
@@ -1,6 +1,6 @@
 <?php
 
-class Application_Model_Resource
+class Application_Model_Resource implements Zend_Acl_Resource_Interface
 {
 
     protected $_id;
@@ -57,6 +57,11 @@ class Application_Model_Resource
     public function getId ()
     {
         return $this->_id;
+    }
+
+    public function getResourceId()
+    {
+        return $this->getId();
     }
 
     public function setControllerName ($controllerName)

--- a/application/models/Role.php
+++ b/application/models/Role.php
@@ -1,6 +1,6 @@
 <?php
 
-class Application_Model_Role
+class Application_Model_Role implements Zend_Acl_Role_Interface
 {
 
     protected $_id;
@@ -61,6 +61,11 @@ class Application_Model_Role
     public function getId ()
     {
         return $this->_id;
+    }
+
+    public function getRoleId()
+    {
+        return $this->getId();
     }
 
     public function setName ($name)

--- a/application/models/mappers/ResourcesMapper.php
+++ b/application/models/mappers/ResourcesMapper.php
@@ -53,18 +53,14 @@ class Application_Model_Mapper_ResourcesMapper
         $this->_setValues($row, $resource);
     }
 
-    public function fetchResources ()
+    public function findByControllerAction($controller, $action, Application_Model_Resource $resource)
     {
-        // Notice: Can't be simplified by _fetch because it has not all columns
-        $resultSet = $this->getDbTable()->fetchResources();
-        $roles = array();
-        foreach ($resultSet as $row) {
-            $role = new Application_Model_Resource();
-            $role->setId($row->id);
-            $role->setControllerName($row->controller_name);
-            $roles[] = $role;
+        $result = $this->getDbTable()->findByControllerAction($controller, $action);
+        if (0 == count($result)) {
+            return;
         }
-        return $roles;
+        $row = $result->current();
+        $this->_setValues($row, $resource);
     }
 
     public function fetchAll ()

--- a/application/plugins/Auth/AccessControll.php
+++ b/application/plugins/Auth/AccessControll.php
@@ -29,15 +29,16 @@ class Application_Plugin_Auth_AccessControll extends Zend_Controller_Plugin_Abst
         
         $controller = $request->getControllerName();
         $action = $request->getActionName();
-        
-        $this->_acl->has($controller) == true ? $resource = $controller : $resource = null;
-        $privilege = $action;
+
+        $resource = new Application_Model_Resource();
+        $resourceMapper = new Application_Model_Mapper_ResourcesMapper();
+        $resourceMapper->findByControllerAction($controller, $action, $resource);
         
         $allowed = false;
         foreach ($userroles as $userrole) {
             $role = new Application_Model_Role();
             $roleMapper->find($userrole->getRoleId(), $role);
-            if ($this->_acl->isAllowed($role->getName(), $resource, $privilege)) {
+            if ($this->_acl->isAllowed($role, $resource)) {
                 $allowed = true;
             }
         }

--- a/application/plugins/Auth/Acl.php
+++ b/application/plugins/Auth/Acl.php
@@ -13,11 +13,10 @@ class Application_Plugin_Auth_Acl extends Zend_Acl
     private function initResources ()
     {
         $mapper = new Application_Model_Mapper_ResourcesMapper();
-        $resources = $mapper->fetchResources();
+        $resources = $mapper->fetchAll();
         
         foreach ($resources as $resource) {
-            $this->addResource(
-                    new Zend_Acl_Resource($resource->getControllerName()));
+            $this->addResource($resource);
         }
     }
 
@@ -27,7 +26,7 @@ class Application_Plugin_Auth_Acl extends Zend_Acl
         $roles = $mapper->fetchAll();
         
         foreach ($roles as $role) {
-            $this->addRole(new Zend_Acl_Role($role->getName()));
+            $this->addRole($role);
         }
     }
 
@@ -43,16 +42,21 @@ class Application_Plugin_Auth_Acl extends Zend_Acl
             $role = new Application_Model_Role();
             $mapperResources->find($right->getResourceId(), $resource);
             $mapperRoles->find($right->getRoleId(), $role);
-            $this->allow($role->getName(), $resource->getControllerName(), 
-                    $resource->getActionName());
+            $this->allow($right->getRoleId(), $right->getResourceId());
         }
-        
+
+        $loginResource = new Application_Model_Resource();
+        $mapperResources->findByControllerAction('auth', 'login', $loginResource);
+
         // Allow everthing to administrator except login (Login not needed
         // 'cause of already logged in)
-        $this->allow('Administrator');
-        $this->deny('Administrator', 'auth', 'login');
-        
+        $this->allow(1);
+        $this->deny(1, $loginResource);
+
+        $errorResource = new Application_Model_Resource();
+        $mapperResources->findByControllerAction('error', '', $errorResource);
+
         // Allow Error-Controller (all Actions) for everyone
-        $this->allow(null, 'error');
+        $this->allow(null, $errorResource);
     }
 }

--- a/application/plugins/Auth/Acl.php
+++ b/application/plugins/Auth/Acl.php
@@ -48,10 +48,15 @@ class Application_Plugin_Auth_Acl extends Zend_Acl
         $loginResource = new Application_Model_Resource();
         $mapperResources->findByControllerAction('auth', 'login', $loginResource);
 
-        // Allow everthing to administrator except login (Login not needed
-        // 'cause of already logged in)
-        $this->allow(1);
-        $this->deny(1, $loginResource);
+        $adminRole = new Application_Model_Role();
+        $mapperRoles->findByRoleName('Administrator', $adminRole);
+
+        if ($adminRoleId = $adminRole->getRoleId()) {
+            // Allow everything to administrator except login (Login not needed
+            // 'cause of already logged in)
+            $this->allow($adminRoleId);
+            $this->deny($adminRoleId, $loginResource);
+        }
 
         $errorResource = new Application_Model_Resource();
         $mapperResources->findByControllerAction('error', '', $errorResource);

--- a/application/views/helpers/RandomGalleryPics.php
+++ b/application/views/helpers/RandomGalleryPics.php
@@ -27,7 +27,7 @@ class Zend_View_Helper_RandomGalleryPics extends Zend_View_Helper_Abstract
             unset($galleries[0]); unset($galleries[1]);
             $galleries = array_values($galleries); // reindex to be sure
 
-            if (empty($galleries)) break; // break if no subfolders are present
+            if (empty($galleries)) return []; // break if no subfolders are present
             
             $i = 0;
             while ($i++ < $count) {

--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1371,7 +1371,6 @@ if (count($args) > count($keyNames)) {
 $whereList = array();
 $numberTerms = 0;
 foreach ($args as $keyPosition => $keyValues) {
-    $keyValuesCount = count($keyValues);
     // Coerce the values to an array.
     // Don't simply typecast to array, because the values
     // might be Zend_Db_Expr objects.
@@ -1380,6 +1379,7 @@ foreach ($args as $keyPosition => $keyValues) {
                 $keyValues
         );
     }
+    $keyValuesCount = count($keyValues);
     if ($numberTerms == 0) {
         $numberTerms = $keyValuesCount;
     } else 


### PR DESCRIPTION
Looking through the logs I found some problematic issue regarding how ACL is handled.  
Biggest issue was the `select` on the database where grouping was applied on only on of the fields (how did this even work!).  

This refactoring uses the IDs of the resources instead of only the controller name as action and controller together are handled as one resource.  
Also the resource and role models are now using the according acl interfaces from zend.